### PR TITLE
Empty project to Identity using --useDefaultUI

### DIFF
--- a/EmptyWeb/Areas/Identity/Data/EmptyWebIdentityDbContext.cs
+++ b/EmptyWeb/Areas/Identity/Data/EmptyWebIdentityDbContext.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace EmptyWeb.Areas.Identity.Data
+{
+    public class EmptyWebIdentityDbContext : IdentityDbContext<IdentityUser>
+    {
+        public EmptyWebIdentityDbContext(DbContextOptions<EmptyWebIdentityDbContext> options)
+            : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            base.OnModelCreating(builder);
+            // Customize the ASP.NET Identity model and override the defaults if needed.
+            // For example, you can rename the ASP.NET Identity table names and more.
+            // Add your customizations after calling base.OnModelCreating(builder);
+        }
+    }
+}

--- a/EmptyWeb/Areas/Identity/IdentityHostingStartup.cs
+++ b/EmptyWeb/Areas/Identity/IdentityHostingStartup.cs
@@ -1,0 +1,30 @@
+using System;
+using EmptyWeb.Areas.Identity.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: HostingStartup(typeof(EmptyWeb.Areas.Identity.IdentityHostingStartup))]
+namespace EmptyWeb.Areas.Identity
+{
+    public class IdentityHostingStartup : IHostingStartup
+    {
+        public void Configure(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices((context, services) => {
+                services.AddDbContext<EmptyWebIdentityDbContext>(options =>
+                    options.UseSqlServer(
+                        context.Configuration.GetConnectionString("EmptyWebIdentityDbContextConnection"),
+                        sqlOptions => sqlOptions.MigrationsAssembly("EmptyWeb")));
+
+                services.AddIdentity<IdentityUser, IdentityRole>()
+                    .AddEntityFrameworkStores<EmptyWebIdentityDbContext>()
+                   .AddDefaultUI()
+                   .AddDefaultTokenProviders();
+            });
+        }
+    }
+}

--- a/EmptyWeb/EmptyWeb.csproj
+++ b/EmptyWeb/EmptyWeb.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.0-preview2-30187" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.1.0-preview2-30187" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.0-preview2-30187" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="2.1.0-preview2-30187" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.0-preview2-30187" />
   </ItemGroup>
   <ItemGroup>

--- a/EmptyWeb/ScaffoldingReadme.txt
+++ b/EmptyWeb/ScaffoldingReadme.txt
@@ -1,0 +1,20 @@
+Support for ASP.NET Core Identity was added to your project
+- The code for adding Identity to your project was generated under Areas/Identity.
+
+Configuration of the Identity related services can be found in the Areas/Identity/IdentityHostingStartup.cs file.
+
+If your app was previously configured to use Identity, then you should remove the call to the AddIdentity method from your ConfigureServices method.
+
+The generated UI requires support for static files. To add static files to your app:
+1. Call app.UseStaticFiles() from your Configure method
+
+To use ASP.NET Core Identity you also need to enable authentication. To authentication to your app:
+1. Call app.UseAuthentication() from your Configure method (after static files)
+
+The generated UI requires MVC. To add MVC to your app:
+1. Call services.AddMvc() from your ConfigureServices method
+2. Call app.UseMvc() from your Configure method (after authentication)
+
+
+Apps that use ASP.NET Core Identity should also use HTTPS. To enable HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.
+

--- a/EmptyWeb/appsettings.json
+++ b/EmptyWeb/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "EmptyWebIdentityDbContextConnection": "Server=(localdb)\\mssqllocaldb;Database=EmptyWeb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  }
+}


### PR DESCRIPTION
## Enable Identity with Default UI in Empty Web project
#### Command line invocation
<kbd>
dotnet aspnet-codegenerator identity --useDefaultUI
</kbd>

#### Result

- This will generate a new DbContext class for the user under `Areas/Identity/Data`
- The `IdentityHostingStartup` class registers this DbContext and also sets up Identity to use DefaultUI.

**_Note_**: This will not add any UI components like `_LoginPartial.cshtml`, `_Layout.cshtml` etc.